### PR TITLE
chore(project): add docker build script and update project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fullstack App - NestJS API + Astro Frontend
+# Sample Project - NestJS API + Astro Frontend
 
 A modern fullstack application built with NestJS backend and Astro frontend, featuring clean
 architecture, TypeScript, and Docker containerization.
@@ -45,7 +45,7 @@ Before you begin, ensure you have the following installed:
 
 ```bash
 git clone <repository-url>
-cd sample-project
+cd {project-name}
 ```
 
 ### 2. Install Dependencies
@@ -125,7 +125,7 @@ yarn workspace @app/web dev
 ## 📁 Project Structure
 
 ```text
-sample-project/
+{project-name}/
 ├── apps/
 │   ├── api/                 # NestJS backend application
 │   │   ├── src/
@@ -208,9 +208,13 @@ yarn workspace @app/web test:watch   # Run tests in watch mode
 
 ```bash
 # Build all Docker images
-yarn docker:build
+yarn docker:build:all
 
 # Build individual images
+yarn docker:build:api
+yarn docker:build:web
+
+# Or build from workspace
 yarn workspace @app/api docker:build
 yarn workspace @app/web docker:build
 ```
@@ -219,8 +223,8 @@ yarn workspace @app/web docker:build
 
 The project includes Dockerfiles to build containerized versions of both applications:
 
-- **API**: `ghcr.io/tituxmetal/sample-project-api`
-- **Web**: `ghcr.io/tituxmetal/sample-project-web`
+- **API**: `ghcr.io/{your-username}/{project-name}-api`
+- **Web**: `ghcr.io/{your-username}/{project-name}-web`
 
 ### CI/CD Pipeline
 
@@ -237,8 +241,20 @@ The CI workflow:
 
 Images are available at:
 
-- `ghcr.io/tituxmetal/sample-project-api:latest`
-- `ghcr.io/tituxmetal/sample-project-web:latest`
+- `ghcr.io/{your-username}/{project-name}-api:latest`
+- `ghcr.io/{your-username}/{project-name}-web:latest`
+
+### Local Development vs Production
+
+The project uses a **dual registry approach** for flexibility:
+
+- **Local Development**: Images built with `scripts/docker-build.sh` use Docker Hub
+  (`{your-dockerhub-org}/{project-name}-*`) for quick testing and iteration
+- **Production Releases**: CI automatically builds and pushes to GitHub Container Registry
+  (`ghcr.io/{your-username}/{project-name}-*`) for official releases
+
+This allows developers to test locally without polluting the production registry, while maintaining
+clean CI/CD for production deployments.
 
 ### Environment Variables
 
@@ -261,7 +277,7 @@ API_URL=http://localhost:3000
 
 # For production deployment
 PUBLIC_API_URL=/api
-API_URL=http://sample-project-api:3000
+API_URL=http://{project-name}-api:3000
 ```
 
 > **Note**: The code uses environment variable fallback pattern:
@@ -269,7 +285,7 @@ API_URL=http://sample-project-api:3000
 >
 > **Build Arguments**: Docker images are built with these environment variables:
 >
-> - `API_URL=http://sample-project-api:3000` (for container-to-container communication)
+> - `API_URL=http://{project-name}-api:3000` (for container-to-container communication)
 > - `PUBLIC_API_URL=/api` (for frontend requests through nginx proxy)
 
 ### Deployment

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,8 +5,8 @@
   "description": "NestJS api with clean architecture for fullstack app",
   "scripts": {
     "build": "nest build",
-    "docker:build": "docker build -f ../../docker/Dockerfile.api -t lgdweb/fullstack-nest-api:prod ../../",
-    "docker:push": "docker push lgdweb/fullstack-nest-api:prod",
+    "docker:build": "../../scripts/docker-build.sh api",
+    "docker:push": "docker push lgdweb/sample-project-api:latest",
     "dev": "nest start --watch",
     "start": "nest start",
     "start:prod": "node dist/main.js",

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,6 +3,6 @@ API_URL=http://localhost:3000
 
 # For production use add the PUBLIC_API_URL=/api and API_URL=http://service-name:3000
 # Make sure to use the service name not the container name when deploy in Portainer Stack
-# Note: Code uses fallback pattern: import.meta.env.API_URL || 'http://fullstack-nest-api:3000'
+# Note: Code uses fallback pattern: import.meta.env.API_URL || 'http://sample-project-api:3000'
 PUBLIC_API_URL=/api
-API_URL=http://fullstack-nest-api:3000
+API_URL=http://sample-project-api:3000

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "astro build",
-    "docker:build": "docker build -f ../../docker/Dockerfile.web --build-arg PUBLIC_API_URL=\"/api\" -t lgdweb/fullstack-astro-web:prod ../../",
-    "docker:push": "docker push lgdweb/fullstack-astro-web:prod",
+    "docker:build": "../../scripts/docker-build.sh web",
+    "docker:push": "docker push lgdweb/sample-project-web:latest",
     "dev": "astro dev",
     "start": "astro preview",
     "lint": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fullstack-app",
+  "name": "sample-project",
   "version": "0.1.0",
   "private": true,
   "description": "Fullstack app with NestJS api and Astro frontend",
@@ -22,7 +22,9 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "start": "turbo run start",
-    "docker:build": "turbo run docker:build --parallel",
+    "docker:build:all": "scripts/docker-build.sh all",
+    "docker:build:api": "scripts/docker-build.sh api",
+    "docker:build:web": "scripts/docker-build.sh web",
     "docker:push": "turbo run docker:push --parallel",
     "test": "turbo run test",
     "test:coverage": "turbo run test:coverage",

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+readonly REGISTRY="lgdweb"
+readonly PROJECT_NAME="sample-project"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly BLUE='\033[0;34m'
+readonly NC='\033[0m'
+
+logInfo() { echo -e "${BLUE}🔨 $*${NC}"; }
+logSuccess() { echo -e "${GREEN}✅ $*${NC}"; }
+logError() { echo -e "${RED}❌ $*${NC}" >&2; }
+
+showHelp() {
+  cat << EOF
+🐳 Docker Build Script
+
+USAGE: $0 <api|web|all> [tag]
+
+EXAMPLES:
+  $0 api              # Build API with latest tag
+  $0 web v1.2.3       # Build web with specific tag
+  $0 all              # Build both services
+
+EOF
+}
+
+buildImage() {
+  local service="$1"
+  local tag="${2:-latest}"
+  local imageName="${REGISTRY}/${PROJECT_NAME}-${service}:${tag}"
+  
+  logInfo "Building $service -> $imageName"
+  
+  cd "$PROJECT_ROOT"
+  
+  local dockerfile="docker/Dockerfile.${service}"
+  local buildArgs=""
+  
+  [[ "$service" == "web" ]] && buildArgs="--build-arg PUBLIC_API_URL=/api"
+  
+  docker buildx build \
+    -f "$dockerfile" \
+    --network=host \
+    $buildArgs \
+    -t "$imageName" \
+    .
+  
+  logSuccess "Built $imageName"
+}
+
+main() {
+  local service="${1:-}"
+  local tag="${2:-latest}"
+  
+  [[ -z "$service" ]] && { showHelp; exit 1; }
+  
+  case "$service" in
+    api|web)
+      buildImage "$service" "$tag"
+      ;;
+    all)
+      buildImage "api" "$tag"
+      buildImage "web" "$tag"
+      ;;
+    *)
+      logError "Invalid service: $service"
+      showHelp
+      exit 1
+      ;;
+  esac
+  
+  logSuccess "Done!"
+}
+
+main "$@"

--- a/turbo.json
+++ b/turbo.json
@@ -15,9 +15,6 @@
       "dependsOn": ["build"],
       "persistent": true
     },
-    "docker:build": {
-      "cache": false
-    },
     "docker:push": {
       "cache": false
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8251,27 +8251,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fullstack-app@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "fullstack-app@workspace:."
-  dependencies:
-    "@changesets/cli": "npm:^2.29.5"
-    "@commitlint/cli": "npm:^19.8.1"
-    "@commitlint/config-conventional": "npm:^19.8.1"
-    "@types/node": "npm:^22.17.1"
-    commitizen: "npm:^4.3.1"
-    cz-conventional-changelog: "npm:^3.3.0"
-    eslint: "npm:^9.33.0"
-    husky: "npm:^9.1.7"
-    lint-staged: "npm:^16.1.5"
-    prettier: "npm:^3.6.2"
-    prettier-plugin-astro: "npm:^0.14.1"
-    prettier-plugin-tailwindcss: "npm:^0.6.14"
-    turbo: "npm:^2.5.5"
-    typescript: "npm:^5.9.2"
-  languageName: unknown
-  linkType: soft
-
 "function-bind@npm:^1.1.2":
   version: 1.1.2
   resolution: "function-bind@npm:1.1.2"
@@ -13629,6 +13608,27 @@ __metadata:
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
   languageName: node
   linkType: hard
+
+"sample-project@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "sample-project@workspace:."
+  dependencies:
+    "@changesets/cli": "npm:^2.29.5"
+    "@commitlint/cli": "npm:^19.8.1"
+    "@commitlint/config-conventional": "npm:^19.8.1"
+    "@types/node": "npm:^22.17.1"
+    commitizen: "npm:^4.3.1"
+    cz-conventional-changelog: "npm:^3.3.0"
+    eslint: "npm:^9.33.0"
+    husky: "npm:^9.1.7"
+    lint-staged: "npm:^16.1.5"
+    prettier: "npm:^3.6.2"
+    prettier-plugin-astro: "npm:^0.14.1"
+    prettier-plugin-tailwindcss: "npm:^0.6.14"
+    turbo: "npm:^2.5.5"
+    typescript: "npm:^5.9.2"
+  languageName: unknown
+  linkType: soft
 
 "sass-formatter@npm:^0.7.6":
   version: 0.7.9


### PR DESCRIPTION
- Add scripts/docker-build.sh for clean Docker image building
- Rename project from fullstack-app to sample-project
- Update Docker image names to lgdweb/sample-project-* pattern
- Add convenience scripts for docker:build:all, docker:build:api, docker:build:web
- Update README.md with dual registry approach documentation
- Make documentation generic and adaptable for new projects
- Update environment examples with consistent service names
- Remove obsolete turbo docker:build task