### PR TITLE
fix(docker): add DATABASE_URL env for Prisma generate

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -16,6 +16,7 @@ RUN yarn workspace @app/api install --immutable
 
 WORKDIR /app/apps/api
 
+ENV DATABASE_URL="file:./dev.db"
 RUN yarn workspace @app/api prisma generate
 
 # Stage 2: Build the application


### PR DESCRIPTION
## Summary
Add DATABASE_URL environment variable for Prisma v7 client generation at build time.

## Problem
Prisma v7 requires DATABASE_URL to be set when running `prisma generate`, even for type generation.

## Solution
Added dummy `DATABASE_URL=file:./dev.db` in Dockerfile.api before `prisma generate`.

This value is only used at build time. Runtime uses the real DATABASE_URL from deployment (Portainer).